### PR TITLE
Support 1.21.1 paper & spigot

### DIFF
--- a/modules/mapping/spigot/pom.xml
+++ b/modules/mapping/spigot/pom.xml
@@ -31,6 +31,7 @@
     <module>v1_20_R3</module>
     <module>v1_20_R4</module>
     <module>v1_21_R1</module>
+    <module>v1_21_R2</module>
     <module>provider</module>
   </modules>
 </project>

--- a/modules/mapping/spigot/provider/pom.xml
+++ b/modules/mapping/spigot/provider/pom.xml
@@ -126,6 +126,12 @@
       <artifactId>mapping-v1_21_R1</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.bitbucket._newage.commandhook</groupId>
+      <artifactId>mapping-v1_21_R2</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/modules/mapping/spigot/provider/src/main/java/org/bitbucket/_newage/commandhook/mapping/SpigotMappingSelector.java
+++ b/modules/mapping/spigot/provider/src/main/java/org/bitbucket/_newage/commandhook/mapping/SpigotMappingSelector.java
@@ -143,6 +143,10 @@ public class SpigotMappingSelector extends MappingSelector {
             mapping = new NmsV1_21_R1();
             break;
 
+        case "1.21.1":
+            mapping = new NmsV1_21_R2();
+            break;
+
         default:
             mapping = null;
         }

--- a/modules/mapping/spigot/v1_21_R2/pom.xml
+++ b/modules/mapping/spigot/v1_21_R2/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.bitbucket._newage.commandhook</groupId>
+    <artifactId>mapping-parent</artifactId>
+    <version>2.0.0</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <name>CommandHook - Mapping 1.21_R2</name>
+  <artifactId>mapping-v1_21_R2</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/modules/mapping/spigot/v1_21_R2/src/main/java/org/bitbucket/_newage/commandhook/mapping/NmsV1_21_R2.java
+++ b/modules/mapping/spigot/v1_21_R2/src/main/java/org/bitbucket/_newage/commandhook/mapping/NmsV1_21_R2.java
@@ -1,0 +1,88 @@
+package org.bitbucket._newage.commandhook.mapping;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandListenerWrapper;
+import net.minecraft.commands.arguments.selector.ArgumentParserSelector;
+import net.minecraft.commands.arguments.selector.EntitySelector;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.world.level.CommandBlockListenerAbstract;
+import net.minecraft.world.level.World;
+import net.minecraft.world.level.block.entity.TileEntityCommand;
+import org.bitbucket._newage.commandhook.mapping.api.AMapping;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_21_R1.CraftWorld;
+import org.bukkit.entity.Entity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NmsV1_21_R2 extends AMapping {
+
+    @Override
+    public List<Entity> getEntitiesFromSelector(String selector, Block commandBlock) {
+        List<Entity> entities = Collections.emptyList();
+
+        CommandListenerWrapper wrapper = getCommandListenerWrapper(commandBlock);
+        ArgumentParserSelector argumentParser = getArgumentParser(selector);
+        try {
+            List<? extends net.minecraft.world.entity.Entity> nmsEntities = getNmsEntities(argumentParser, wrapper);
+            entities = convertToBukkitEntity(nmsEntities);
+        } catch (CommandSyntaxException ex) {
+            handleCommandSyntaxException(commandBlock, ex);
+        }
+
+        return entities;
+    }
+
+    /**
+     * Vanilla CommandListenerWrapper
+     * @param block
+     * @return
+     */
+    @Override
+    public CommandListenerWrapper getCommandListenerWrapper(Block block) {
+        World world = ((CraftWorld) block.getWorld()).getHandle();
+        BlockPosition blockPosition = new BlockPosition(block.getX(), block.getY(), block.getZ());
+
+        TileEntityCommand tileEntityCommand = (TileEntityCommand) world.getBlockEntity(blockPosition, true);
+        CommandBlockListenerAbstract commandBlockListenerAbstract = tileEntityCommand.b();
+        return commandBlockListenerAbstract.i();
+    }
+
+    /**
+     * Vanilla Argument Parser Selector
+     * @param selector
+     * @return
+     */
+    @Override
+    public ArgumentParserSelector getArgumentParser(String selector) {
+        StringReader stringReader = new StringReader(selector);
+        return new ArgumentParserSelector(stringReader, true);
+    }
+
+    /**
+     * Vanilla Entities
+     * @param argumentParser
+     * @param wrapper
+     * @return
+     * @throws CommandSyntaxException
+     */
+    private List<? extends net.minecraft.world.entity.Entity> getNmsEntities(ArgumentParserSelector argumentParser, CommandListenerWrapper wrapper) throws CommandSyntaxException {
+        EntitySelector selector = argumentParser.parse(false);
+        return selector.b(wrapper);
+    }
+
+    /**
+     * Spigot related
+     * @param entities
+     * @return
+     */
+    private List<Entity> convertToBukkitEntity(List<? extends net.minecraft.world.entity.Entity> entities) {
+        return entities.stream()
+                .map(net.minecraft.world.entity.Entity::getBukkitEntity)
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
This pr addes support for paper & spigot 1.21.1 and closes #10

The most critical change was that the ArgumentParserSelector constructor now also wants a boolean, if at selector is applyable.

_This update was a commissioned by mindofsocial_